### PR TITLE
General fixes

### DIFF
--- a/Tinke/Autores.Designer.cs
+++ b/Tinke/Autores.Designer.cs
@@ -132,7 +132,7 @@ namespace Tinke
             this.linkLabel1.Size = new System.Drawing.Size(164, 13);
             this.linkLabel1.TabIndex = 5;
             this.linkLabel1.TabStop = true;
-            this.linkLabel1.Text = "http://code.google.com/p/tinke/";
+            this.linkLabel1.Text = "http://www.github.com/pleonex/tinke/";
             // 
             // label5
             // 

--- a/Tinke/RomInfo.cs
+++ b/Tinke/RomInfo.cs
@@ -235,9 +235,9 @@ namespace Tinke
             o.CheckPathExists = true;
             o.DefaultExt = ".bmp";
             o.OverwritePrompt = true;
-            o.Filter = "Imagen Bitmap (*.bmp)|*.bmp";
+            o.Filter = "Imagen Bitmap (*.bmp)|*.bmp|PNG image|*.png|GIF image|*.gif|JPEG image|*.jpg;*.jpeg;*.jpe;*.jif;*.jfif;*.jfi|TIFF image|*.tif;*.tiff";
             if (o.ShowDialog() == System.Windows.Forms.DialogResult.OK)
-                picIcon.Image.Save(o.FileName, System.Drawing.Imaging.ImageFormat.Bmp);
+                picIcon.Image.Save(o.FileName);
         }
         private void comboBannerLang_SelectedIndexChanged(object sender, EventArgs e)
         {

--- a/Tinke/app.config
+++ b/Tinke/app.config
@@ -1,3 +1,6 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+  <runtime>
+    <loadFromRemoteSources enabled="true"/>
+  </runtime>
+</configuration>

--- a/Tinke/langs/en-us.xml
+++ b/Tinke/langs/en-us.xml
@@ -58,19 +58,19 @@
       from this folder?. It can take a long time...
     </S35>
     <S36>
-      The uncompression is unsuccessfully.
-      Are you sure is a compressed file?
+      The uncompression was unsuccessful.
+      Are you sure it is a compressed file?
     </S36>
     <S37>There was an error saving the user preferences.</S37>
     <S38>There was an error loading the user preferences.</S38>
     <S39>
       You have changed some files but the new ROM is not saved
-      Are you sure you want exit? All the changes will be lost.
+      Are you sure you want to exit? All the changes will be lost.
     </S39>
     <S3A>Warning</S3A>
     <S3B>
       Do you want to export the uncompressed folder instead of
-      the compress file?
+      the compressed file?
     </S3B>
     <S3C>Full file information</S3C>
     <S3D>Pack</S3D>
@@ -84,7 +84,7 @@
       Check the debug messages.
     </S43>
     <S44>
-      Sorry, you can't overwrite the current 
+      Sorry, you can't overwrite the currently 
       opened file.
     </S44>
     <S45>Refresh messages</S45>
@@ -221,7 +221,7 @@
       {0}
 
       Please, download the program from the web page:
-      http://code.google.com/p/tinke
+      http://www.github.com/pleonex/tinke
     </S1F>
     <S20>
       Error loading the file: {0}.

--- a/Tinke/langs/es-es.xml
+++ b/Tinke/langs/es-es.xml
@@ -234,7 +234,7 @@
       {0}
 
       Por favor descargue el programa de nuevo desde:
-      http://code.google.com/p/tinke
+      http://www.github.com/pleonex/tinke
     </S1F>
     <S20>
       Error al cargar el archivo: {0}.

--- a/Tinke/langs/fr-fr.xml
+++ b/Tinke/langs/fr-fr.xml
@@ -218,7 +218,7 @@
       {0}
 
       Veuillez télécharger le programme depuis la page web :
-      http://code.google.com/p/tinke
+      http://www.github.com/pleonex/tinke
     </S1F>
     <S20>
       Erreur de chargement de l'archive : {0}.

--- a/Tinke/langs/it-it.xml
+++ b/Tinke/langs/it-it.xml
@@ -221,7 +221,7 @@
       {0}
 
       Per favore, scarica il programma dalla pagina web:
-      http://code.google.com/p/tinke
+      http://www.github.com/pleonex/tinke
     </S1F>
     <S20>
       Errore nel caricamento del file: {0}.

--- a/compile.bat
+++ b/compile.bat
@@ -98,6 +98,7 @@ REM Copy license and changelog
 ECHO Copying license and changelog
 COPY "%cd%\changelog.txt" "%build_dir%\" > nul || (EXIT /B 1)
 COPY "%cd%\Licence.txt" "%build_dir%\" > nul || (EXIT /B 1)
+COPY "%cd%\Tinke\app.config" "%build_dir%\Tinke.exe.config" > nul || (EXIT /B 1)
 
 REM Delete debug files
 ECHO Removing debug files

--- a/compile.sh
+++ b/compile.sh
@@ -114,6 +114,7 @@ cp "$TINKE_DIR/Plugins/3DModels/OpenTK.GLControl.dll" "$BUILD_DIR/"
 # Copy license and changelog
 cp "$TINKE_DIR/changelog.txt" "$BUILD_DIR/"
 cp "$TINKE_DIR/Licence.txt" "$BUILD_DIR/"
+cp "$TINKE_DIR/Tinke/app.config" "$BUILD_DIR/"
 
 # Delete debug files
 rm "$BUILD_DIR"/*.mdb


### PR DESCRIPTION
Fixes made:
- Added [&lt;loadFromRemoteSources&gt;](https://msdn.microsoft.com/en-us/library/dd409252(VS.100).aspx) tag to Tinke/app.config - this fixes compatibility with Windows XP
- The banner image can now be saved as a PNG, GIF, JPEG or TIFF file instead of a BMP file.
- Replaced Google Code links with GitHub links
- Fixed several typos