### PR TITLE
NFTR: PAMC sorts and rotation fix; DSDecmp: BLZ fix; Ekona/Images: new force swapping

### DIFF
--- a/Ekona/Images/ImageControl.cs
+++ b/Ekona/Images/ImageControl.cs
@@ -475,16 +475,20 @@ namespace Ekona.Images
                 tiles = bmp.Tiles;
                 pal = bmp.Palette.Palette[0];
             }
-            else
+            else if (this.radioReplacePal.Checked)
             {
                 try { Actions.Indexed_Image(bitmap, image.FormatColor, out tiles, out pal); }
                 catch (Exception ex) { MessageBox.Show(ex.Message); Console.WriteLine(ex.Message); return; }
             }
 
             // Swap palettes if "Swap palette" is checked. Try to change the colors to the old palette
-            if (radioSwapPal.Checked)
+            else if (radioSwapPal.Checked)
             {
-                try { Actions.Swap_Palette(ref tiles, palette.Palette[(int)numPal.Value], pal, image.FormatColor); }
+                try
+                {
+                    //Actions.Swap_Palette(ref tiles, palette.Palette[(int)numPal.Value], pal, image.FormatColor);
+                    tiles = Actions.IndexAndSwap(bitmap, image.FormatColor, palette.Palette[(int)numPal.Value]);
+                }
                 catch (Exception ex) { MessageBox.Show(ex.Message); Console.WriteLine(ex.Message); return; }
             }
 

--- a/Ekona/Mathematics/NvMath.cs
+++ b/Ekona/Mathematics/NvMath.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Ekona.Mathematics
 {

--- a/Ekona/Mathematics/Vector3.cs
+++ b/Ekona/Mathematics/Vector3.cs
@@ -25,7 +25,6 @@ namespace Ekona.Mathematics
     using System.Collections.Generic;
     using System.Globalization;
     using System.Text;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// Vector 3D

--- a/Plugins/Fonts/Fonts/MapChar.cs
+++ b/Plugins/Fonts/Fonts/MapChar.cs
@@ -116,21 +116,19 @@ namespace Fonts
                 switch (map.type_section)
                 {
                     case 0:
-                        size += 2;
+                        size += 4;
                         break;
-
                     case 1:
                         sNFTR.PAMC.Type1 type1 = (sNFTR.PAMC.Type1)map.info;
                         size += (uint)type1.char_code.Length * 2;
+                        if (type1.char_code.Length % 2 > 0) size += 2;
                         break;
-
                     case 2:
                         sNFTR.PAMC.Type2 type2 = (sNFTR.PAMC.Type2)map.info;
-                        size += 2;
+                        size += 4;
                         size += (uint)type2.charInfo.Length * 4;
                         break;
                 }
-                size += 2;  // 0x00 terminator
 
                 map.block_size = size;
                 maps[i] = map;

--- a/Plugins/Fonts/Fonts/NFTR.cs
+++ b/Plugins/Fonts/Fonts/NFTR.cs
@@ -28,6 +28,8 @@ using Ekona;
 
 namespace Fonts
 {
+    using System.Drawing.Imaging;
+    using System.Runtime.InteropServices;
 
     // Credits to CUE and Lyan53 in romxhack, thanks:
     // http://romxhack.esforos.com/fuentes-nftr-de-nds-t67
@@ -460,19 +462,32 @@ namespace Fonts
                 tileData.Add(byteFromBits);
             }
 
-
+            byte[] argbData = new byte[4 * image.Width * image.Height];
             for (int h = 0; h < height; h++)
             {
                 for (int w = 0; w < width; w++)
                 {
                     for (int hzoom = 0; hzoom < zoom; hzoom++)
                         for (int wzoom = 0; wzoom < zoom; wzoom++)
-                            image.SetPixel(
-                                w * zoom + wzoom,
-                                h * zoom + hzoom,
-                                (palette[tileData[w + h * width]]));
+                        {
+                            //image.SetPixel(w * zoom + wzoom, h * zoom + hzoom, (palette[tileData[w + h * width]]));
+                            int x = w * zoom + wzoom;
+                            int y = h * zoom + hzoom;
+                            int p = y * image.Width + x;
+                            argbData[4 * p + 0] = palette[tileData[w + h * width]].B;
+                            argbData[4 * p + 1] = palette[tileData[w + h * width]].G;
+                            argbData[4 * p + 2] = palette[tileData[w + h * width]].R;
+                            argbData[4 * p + 3] = palette[tileData[w + h * width]].A;
+                        }
                 }
             }
+
+            BitmapData bmpData = image.LockBits(
+                new Rectangle(Point.Empty, image.Size),
+                ImageLockMode.WriteOnly,
+                PixelFormat.Format32bppArgb);
+            Marshal.Copy(argbData, 0, bmpData.Scan0, argbData.Length);
+            image.UnlockBits(bmpData);
 
             return image;
         }

--- a/Plugins/Fonts/Fonts/NFTR.cs
+++ b/Plugins/Fonts/Fonts/NFTR.cs
@@ -269,6 +269,18 @@ namespace Fonts
                 for (; rem < 4; rem++)
                     bw.Write((byte)0x00);
 
+            // Sorts of CMAPs by type
+            sNFTR.PAMC[] cmaps = new sNFTR.PAMC[font.pamc.Count];
+            uint[] types = new uint[font.pamc.Count];
+            for (int i = 0; i < cmaps.Length; i++)
+            {
+                cmaps[i] = font.pamc[i];
+                types[i] = font.pamc[i].type_section;
+            }
+
+            Array.Sort(types, cmaps);
+            font.pamc = new List<sNFTR.PAMC>(cmaps);
+
             // Write the PAMC section
             for (int i = 0; i < font.pamc.Count; i++)
             {
@@ -288,11 +300,13 @@ namespace Fonts
                     case 0:
                         sNFTR.PAMC.Type0 type0 = (sNFTR.PAMC.Type0)font.pamc[i].info;
                         bw.Write(type0.fist_char_code);
+                        bw.Write((ushort)0x00);
                         break;
                     case 1:
                         sNFTR.PAMC.Type1 type1 = (sNFTR.PAMC.Type1)font.pamc[i].info;
                         for (int j = 0; j < type1.char_code.Length; j++)
                             bw.Write(type1.char_code[j]);
+                        if (type1.char_code.Length % 2 > 0) bw.Write((ushort)0x00);
                         break;
                     case 2:
                         sNFTR.PAMC.Type2 type2 = (sNFTR.PAMC.Type2)font.pamc[i].info;
@@ -302,9 +316,9 @@ namespace Fonts
                             bw.Write(type2.charInfo[j].chars_code);
                             bw.Write(type2.charInfo[j].chars);
                         }
+                        bw.Write((ushort)0x00);
                         break;
                 }
-                bw.Write((ushort)0x00);
             }
 
             bw.Flush();

--- a/Plugins/Fonts/Fonts/NFTR.cs
+++ b/Plugins/Fonts/Fonts/NFTR.cs
@@ -91,15 +91,20 @@ namespace Fonts
             for (int i = 0; i < font.plgc.tiles.Length; i++)
             {
                 font.plgc.tiles[i] = BytesToBits(br.ReadBytes(font.plgc.tile_length));
-                if (font.plgc.rotateMode == 2)
+                if (font.plgc.rotateMode >> 1 == 3)
                     font.plgc.tiles[i] = Rotate270(font.plgc.tiles[i], font.plgc.tile_width, font.plgc.tile_height, font.plgc.depth);
-                else if (font.plgc.rotateMode == 1)
+                else if (font.plgc.rotateMode >> 1 == 1)
                     font.plgc.tiles[i] = Rotate90(font.plgc.tiles[i], font.plgc.tile_width, font.plgc.tile_height, font.plgc.depth);
-                else if (font.plgc.rotateMode == 3)
+                else if (font.plgc.rotateMode >> 1 == 2)
                     font.plgc.tiles[i] = Rotate180(font.plgc.tiles[i], font.plgc.tile_width, font.plgc.tile_height, font.plgc.depth);
-
             }
 
+            if (font.plgc.rotateMode >> 1 % 2 != 0)
+            {
+                byte w = font.plgc.tile_width;
+                font.plgc.tile_width = font.plgc.tile_height;
+                font.plgc.tile_height = w;
+            }
 
             // Character Width DH
             br.BaseStream.Position = font.fnif.offset_hdwc - 0x08;
@@ -168,7 +173,7 @@ namespace Fonts
             } while (nextOffset != 0x00 && (nextOffset - 0x08) < br.BaseStream.Length);
 
             //WriteInfo(font, lang);
-            font.plgc.rotateMode = 0;
+            font.plgc.rotateMode &= 1;
 
             br.Close();
             return font;
@@ -488,7 +493,6 @@ namespace Fonts
         public static Byte[] Rotate270(Byte[] bytes,int width, int height, int depth)
         {
             Byte[] rotated = new Byte[bytes.Length];
-
             for (int h = 0; h < height; h++)
             {
                 for (int w = 0; w < width; w++)
@@ -497,7 +501,7 @@ namespace Fonts
                     Array.Copy(bytes, (w + h * width) * depth, original, 0, depth);
 
                     for (int i = 0; i < depth; i++)
-                        rotated[(h + width * (height - 1) - w * width) * depth + i] = original[i];
+                        rotated[(w * height + (height - h - 1)) * depth + i] = original[i];
                 }
             }
 
@@ -515,7 +519,7 @@ namespace Fonts
                     Array.Copy(bytes, (w + h * width) * depth, original, 0, depth);
 
                     for (int i = 0; i < depth; i++)
-                        rotated[((width - 1 - h) + w * width) * depth + i] = original[i];
+                        rotated[(h + height * (width - 1 - w)) * depth + i] = original[i];
                 }
             }
 

--- a/Plugins/Fonts/Fonts/Properties/AssemblyInfo.cs
+++ b/Plugins/Fonts/Fonts/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Tinke")]
-[assembly: AssemblyCopyright("pleoNeX, CUE, Lyan53")]
+[assembly: AssemblyCopyright("pleoNeX, CUE, Lyan53, MetLob")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Puede especificar todos los valores o establecer como predeterminados los números de versión de compilación y de revisión 
 // mediante el asterisco ('*'), como se muestra a continuación:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.1.0")]
-[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyVersion("2.1.2.0")]
+[assembly: AssemblyFileVersion("2.1.2.0")]


### PR DESCRIPTION
NFTR:
-------
Sorting of char mapping sections (PAMC) needed for correct works. Sorting by type.
rotateFlag: shift >> 1. ShiftedRotateFlag:
0 - not rotated
1 - 90 degree
2 - 180 degree
3 - 270 degree

Optimization is call removing of the SetPixel - this is calls Bitmap locks and unlocks every time.
So I call LockBits and Unlockbits 1 time only.

Ekona
--------
I added new method for swapping colors without unique condition. If new color didn't exist in old palette then swapping to nearest color.